### PR TITLE
Document scoped plugin runtime capabilities

### DIFF
--- a/en/ai/plugin/plugin-sdk/runtime-capabilities.mdx
+++ b/en/ai/plugin/plugin-sdk/runtime-capabilities.mdx
@@ -70,12 +70,26 @@ The registry is scoped by the host. Capability methods still enforce tenant, org
 
 ## Resolve a capability in a NestJS provider
 
-Server-side plugin providers can inject the platform registry. Keep the dependency optional when the plugin can load on a host version that does not provide the capability:
+A NestJS provider is not inherently bound to one Agent execution, so first distinguish whether a capability depends on the current runtime scope:
+
+| Consumer | Resolution path |
+| --- | --- |
+| Agent middleware | Use `context.runtime.capabilities` directly. |
+| A user-, Xpert-, or Project-scoped capability in a NestJS provider | Inject `XPERT_AGENT_MIDDLEWARE_RUNTIME_TOKEN` and call `createScopedApi(scope)` for each operation. |
+| A global capability that does not depend on a data owner | Inject `XPERT_RUNTIME_CAPABILITIES_TOKEN`. |
+
+Data-owning capabilities such as `WorkspaceFilesRuntimeCapability` must be resolved from the scoped runtime API first. An unbound global registry may intentionally omit Workspace Files when no `xpertId` or `projectId` is bound. A plugin must not work around that boundary by asking the host to restore unscoped file access.
+
+The following example creates a scoped API for each export operation. The global registry is only a compatibility fallback for older hosts; omit that fallback in a new plugin that does not support those hosts:
 
 ```ts
 import { Inject, Injectable, Optional } from '@nestjs/common'
 import {
+  WorkspaceFilesRuntimeCapability,
+  XPERT_AGENT_MIDDLEWARE_RUNTIME_TOKEN,
   XPERT_RUNTIME_CAPABILITIES_TOKEN,
+  type AgentMiddlewareRuntimeScope,
+  type AgentMiddlewareRuntimeServiceApi,
   type RuntimeCapabilityRegistry
 } from '@xpert-ai/plugin-sdk'
 
@@ -83,13 +97,31 @@ import {
 export class ExportService {
   constructor(
     @Optional()
+    @Inject(XPERT_AGENT_MIDDLEWARE_RUNTIME_TOKEN)
+    private readonly runtimeService?: AgentMiddlewareRuntimeServiceApi,
+    @Optional()
     @Inject(XPERT_RUNTIME_CAPABILITIES_TOKEN)
-    private readonly capabilities?: RuntimeCapabilityRegistry
+    private readonly globalCapabilities?: RuntimeCapabilityRegistry
   ) {}
+
+  private workspaceFiles(scope: AgentMiddlewareRuntimeScope) {
+    const files = this.runtimeService
+      ?.createScopedApi(scope)
+      .capabilities?.get(WorkspaceFilesRuntimeCapability)
+      ?? this.globalCapabilities?.get(WorkspaceFilesRuntimeCapability)
+
+    if (!files) {
+      throw new Error('Workspace Files is unavailable in the current runtime scope')
+    }
+
+    return files
+  }
 }
 ```
 
-Resolve the capability close to the operation so availability can be reported accurately. Do not cache user- or execution-scoped results across requests.
+The `tenantId`, `organizationId`, `userId`, `xpertId`, `projectId`, `conversationId`, `catalog`, and `scopeId` passed to `createScopedApi()` must come from host-resolved server context, never from untrusted iframe, form, or action-input identifiers.
+
+Create the scoped API and resolve the capability close to each operation so availability is reported accurately. Do not cache user- or execution-scoped APIs or capability instances across requests.
 
 ## Capabilities in the runtime package
 
@@ -153,6 +185,7 @@ Production plugin code normally consumes platform keys; host infrastructure owns
 ## Compatibility rules
 
 - Import keys and API types from `@xpert-ai/plugin-sdk`; do not copy the interfaces into a plugin.
+- A NestJS provider that consumes a scope-sensitive capability must use `XPERT_AGENT_MIDDLEWARE_RUNTIME_TOKEN.createScopedApi()`; do not use an unbound global registry as its primary source.
 - Treat capability availability as a runtime condition. Package installation alone does not prove that a host service, provider, binding, or registered Sandbox Action is ready.
 - Keep portable references and structured DTOs at async boundaries. Do not pass raw file bytes, bearer tokens, host paths, or implementation instances through queues or persisted chat metadata.
 - Keep capability results within the current authorized scope and re-resolve them for later jobs or callbacks.

--- a/en/ai/plugin/plugin-sdk/workspace-files.mdx
+++ b/en/ai/plugin/plugin-sdk/workspace-files.mdx
@@ -19,11 +19,50 @@ type WorkspaceFileCatalog =
   | 'knowledges'
   | 'skills'
   | 'xperts'
+  | 'user-xperts'
 ```
 
 Explicit APIs accept `WorkspaceFileScope` fields such as `tenantId`, `organizationId`, `userId`, `catalog`, `scopeId`, `projectId`, `knowledgeId`, `rootId`, and `xpertId`. Runtime-aware APIs infer the current Agent workspace when possible.
 
+For files in the current Agent runtime, the host exposes the capability only after binding a concrete data owner: Project mode binds `projectId`, while non-Project mode binds `xpertId`. A personal Xpert uses `catalog: 'user-xperts'`, where `scopeId` is the Xpert ID and `userId` remains a separate user-isolation field. Never concatenate `userId` and `xpertId` into one `scopeId`.
+
 `filePath` is always relative to a workspace Volume. It is not `/workspace/...` and is never a host/API-process filesystem path.
+
+## Resolve Workspace Files in a NestJS provider
+
+Agent middleware uses `context.runtime.capabilities` directly. A View Provider, controller, or other NestJS service must inject `XPERT_AGENT_MIDDLEWARE_RUNTIME_TOKEN` and create a scoped API from host-resolved context:
+
+```ts
+import { Inject, Optional } from '@nestjs/common'
+import {
+  WorkspaceFilesRuntimeCapability,
+  XPERT_AGENT_MIDDLEWARE_RUNTIME_TOKEN,
+  type AgentMiddlewareRuntimeScope,
+  type AgentMiddlewareRuntimeServiceApi
+} from '@xpert-ai/plugin-sdk'
+
+export class DocumentService {
+  constructor(
+    @Optional()
+    @Inject(XPERT_AGENT_MIDDLEWARE_RUNTIME_TOKEN)
+    private readonly runtimeService?: AgentMiddlewareRuntimeServiceApi
+  ) {}
+
+  workspaceFiles(scope: AgentMiddlewareRuntimeScope) {
+    const files = this.runtimeService
+      ?.createScopedApi(scope)
+      .capabilities?.get(WorkspaceFilesRuntimeCapability)
+
+    if (!files) {
+      throw new Error('Workspace Files is unavailable in the current runtime scope')
+    }
+
+    return files
+  }
+}
+```
+
+Do not resolve Workspace Files only from `XPERT_RUNTIME_CAPABILITIES_TOKEN` inside a provider. That token represents the global capability set without a bound data owner, and current hosts intentionally omit `WorkspaceFilesRuntimeCapability` from it. See [Runtime Capabilities](./runtime-capabilities#resolve-a-capability-in-a-nestjs-provider) for the complete provider rules.
 
 ## Choose the right reference
 
@@ -137,6 +176,7 @@ if (status.vectorIndexStatus === 'ready') {
 
 ## Safety and lifecycle
 
+- Create a scoped API from host-resolved server context for each request. Do not cache file capability instances across users, Xperts, Projects, or requests.
 - Prefer `resolveFile()` when only metadata or an openable URL is required; use byte-reading methods only for actual processing.
 - Never pass `/workspace/...` paths into a delayed job. Convert them with `resolveRuntimeReference()` first.
 - Validate stored evidence with `validateUnderstandingReferences()` before presenting or acting on it.

--- a/zh-Hans/ai/plugin/plugin-sdk/runtime-capabilities.mdx
+++ b/zh-Hans/ai/plugin/plugin-sdk/runtime-capabilities.mdx
@@ -70,12 +70,26 @@ if (!files) {
 
 ## 在 NestJS 服务提供器中解析能力
 
-服务端插件的服务提供器可以注入平台能力注册表。若插件需要兼容尚未提供该能力的宿主版本，请将依赖声明为可选：
+NestJS 服务提供器不天然绑定某一次智能体执行，因此必须先区分能力是否依赖当前运行作用域：
+
+| 使用位置 | 获取方式 |
+| --- | --- |
+| 智能体中间件 | 直接使用 `context.runtime.capabilities`。 |
+| NestJS Provider 中与用户、Xpert 或 Project 绑定的能力 | 注入 `XPERT_AGENT_MIDDLEWARE_RUNTIME_TOKEN`，并为每次操作调用 `createScopedApi(scope)`。 |
+| 与数据所有者无关的全局能力 | 注入 `XPERT_RUNTIME_CAPABILITIES_TOKEN`。 |
+
+`WorkspaceFilesRuntimeCapability` 等涉及数据归属的能力必须优先从 scoped runtime API 获取。未绑定 `xpertId` 或 `projectId` 的全局注册表可能会故意不提供工作区文件能力，插件不能通过放宽宿主权限来绕过这个限制。
+
+下面的示例在每次导出操作时创建作用域能力。全局注册表只作为兼容旧宿主的回退，新插件如果不需要兼容旧宿主，可以省略该回退：
 
 ```ts
 import { Inject, Injectable, Optional } from '@nestjs/common'
 import {
+  WorkspaceFilesRuntimeCapability,
+  XPERT_AGENT_MIDDLEWARE_RUNTIME_TOKEN,
   XPERT_RUNTIME_CAPABILITIES_TOKEN,
+  type AgentMiddlewareRuntimeScope,
+  type AgentMiddlewareRuntimeServiceApi,
   type RuntimeCapabilityRegistry
 } from '@xpert-ai/plugin-sdk'
 
@@ -83,13 +97,31 @@ import {
 export class ExportService {
   constructor(
     @Optional()
+    @Inject(XPERT_AGENT_MIDDLEWARE_RUNTIME_TOKEN)
+    private readonly runtimeService?: AgentMiddlewareRuntimeServiceApi,
+    @Optional()
     @Inject(XPERT_RUNTIME_CAPABILITIES_TOKEN)
-    private readonly capabilities?: RuntimeCapabilityRegistry
+    private readonly globalCapabilities?: RuntimeCapabilityRegistry
   ) {}
+
+  private workspaceFiles(scope: AgentMiddlewareRuntimeScope) {
+    const files = this.runtimeService
+      ?.createScopedApi(scope)
+      .capabilities?.get(WorkspaceFilesRuntimeCapability)
+      ?? this.globalCapabilities?.get(WorkspaceFilesRuntimeCapability)
+
+    if (!files) {
+      throw new Error('当前运行作用域未提供工作区文件能力')
+    }
+
+    return files
+  }
 }
 ```
 
-应在实际操作附近解析能力，以便准确报告可用性。不要跨请求缓存与用户或执行上下文绑定的结果。
+传给 `createScopedApi()` 的 `tenantId`、`organizationId`、`userId`、`xpertId`、`projectId`、`conversationId`、`catalog` 和 `scopeId` 必须来自宿主已解析的服务端上下文，不能来自 iframe、表单或 action input 中未经信任的 ID。
+
+应在实际操作附近重新创建 scoped API 并解析能力，以便准确报告可用性。不要跨请求缓存与用户或执行上下文绑定的 API 或能力实例。
 
 ## 运行时包中的能力
 
@@ -153,6 +185,7 @@ const capabilities = new DefaultRuntimeCapabilityRegistry().register(
 ## 兼容性规则
 
 - 从 `@xpert-ai/plugin-sdk` 导入能力键和 API 类型，不要在插件中复制接口。
+- NestJS Provider 消费作用域敏感能力时，必须使用 `XPERT_AGENT_MIDDLEWARE_RUNTIME_TOKEN.createScopedApi()`；不要把未绑定数据所有者的全局注册表作为主要来源。
 - 将能力可用性视为运行时条件。插件安装成功，并不代表宿主服务、提供器、绑定或已注册沙箱操作一定就绪。
 - 在异步边界传递可移植引用和结构化 DTO，不要通过队列或持久化聊天元数据传递原始文件字节、持有者令牌、宿主路径或实现实例。
 - 将能力返回值限制在当前授权范围内；后续任务或回调应重新解析所需资源。

--- a/zh-Hans/ai/plugin/plugin-sdk/workspace-files.mdx
+++ b/zh-Hans/ai/plugin/plugin-sdk/workspace-files.mdx
@@ -19,11 +19,50 @@ type WorkspaceFileCatalog =
   | 'knowledges'
   | 'skills'
   | 'xperts'
+  | 'user-xperts'
 ```
 
 显式 API 接收 `WorkspaceFileScope` 中的 `tenantId`、`organizationId`、`userId`、`catalog`、`scopeId`、`projectId`、`knowledgeId`、`rootId` 和 `xpertId` 等字段。运行时感知 API 会尽可能从当前智能体工作区推导作用域。
 
+对于当前 Agent 的运行时文件，宿主只会在绑定明确数据所有者时提供能力：Project 模式绑定 `projectId`；非 Project 模式绑定 `xpertId`。个人 Xpert 使用 `catalog: 'user-xperts'`，其中 `scopeId` 是 Xpert ID，`userId` 作为独立字段保留用户隔离。不要把 `userId` 和 `xpertId` 拼进一个 `scopeId`。
+
 `filePath` 始终是相对工作区存储卷的路径，不是 `/workspace/...`，也不是宿主或 API 进程的文件系统路径。
+
+## 在 NestJS Provider 中获取文件能力
+
+智能体中间件直接使用 `context.runtime.capabilities`。View Provider、Controller 或其他 NestJS 服务必须使用 `XPERT_AGENT_MIDDLEWARE_RUNTIME_TOKEN`，根据宿主解析出的当前作用域创建 scoped API：
+
+```ts
+import { Inject, Optional } from '@nestjs/common'
+import {
+  WorkspaceFilesRuntimeCapability,
+  XPERT_AGENT_MIDDLEWARE_RUNTIME_TOKEN,
+  type AgentMiddlewareRuntimeScope,
+  type AgentMiddlewareRuntimeServiceApi
+} from '@xpert-ai/plugin-sdk'
+
+export class DocumentService {
+  constructor(
+    @Optional()
+    @Inject(XPERT_AGENT_MIDDLEWARE_RUNTIME_TOKEN)
+    private readonly runtimeService?: AgentMiddlewareRuntimeServiceApi
+  ) {}
+
+  workspaceFiles(scope: AgentMiddlewareRuntimeScope) {
+    const files = this.runtimeService
+      ?.createScopedApi(scope)
+      .capabilities?.get(WorkspaceFilesRuntimeCapability)
+
+    if (!files) {
+      throw new Error('当前运行作用域未提供工作区文件能力')
+    }
+
+    return files
+  }
+}
+```
+
+不要在 Provider 中只从 `XPERT_RUNTIME_CAPABILITIES_TOKEN` 获取工作区文件。该令牌表示未绑定具体数据所有者的全局能力集合，新宿主会故意从中省略 `WorkspaceFilesRuntimeCapability`。完整的 Provider 获取规则见[运行时能力](./runtime-capabilities#在-nestjs-服务提供器中解析能力)。
 
 ## 选择正确的引用类型
 
@@ -137,6 +176,7 @@ if (status.vectorIndexStatus === 'ready') {
 
 ## 安全与生命周期
 
+- 每次请求都根据宿主解析的服务端上下文创建 scoped API；不要跨用户、Xpert、Project 或请求缓存文件能力实例。
 - 只需要元数据或可打开 URL 时优先使用 `resolveFile()`；只有实际处理内容时才读取字节。
 - 不要将 `/workspace/...` 路径放入延迟任务；应先用 `resolveRuntimeReference()` 转换。
 - 在展示证据或据此执行操作前，使用 `validateUnderstandingReferences()` 重新校验证据。


### PR DESCRIPTION
## Summary

- explain when plugin providers must resolve capabilities through the scoped Agent middleware runtime
- document Workspace Files ownership for Project, Xpert, and personal user-xperts scopes
- add matching Chinese and English examples and safety guidance

## Validation

- git diff --check origin/main...HEAD
- node generate-navigation.mjs --dry-run